### PR TITLE
Fix syntax error in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "keywords": [
       "magento 2",
       "magento 2 widget",
-      "magento 2 catalog widget"
+      "magento 2 catalog widget",
       "catalog widget",
       "sort widget"
     ],


### PR DESCRIPTION
Missing comma on line 22 causes composer installs to break.  Added missing comma to fix.